### PR TITLE
TEN-157 added in action into every controller to get access to account type

### DIFF
--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/ErrorHandler.scala
@@ -18,9 +18,8 @@ package uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers
 
 import com.google.inject.Inject
 import play.api.Logger
-import play.api.i18n.{I18nSupport, Messages}
+import play.api.i18n.I18nSupport
 import play.api.mvc.{MessagesControllerComponents, Result}
-import play.api.mvc.Results.{InternalServerError, Redirect}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.actions.RequestWithUserDetailsFromSession
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.errors.{InvalidUserType, TaxEnrolmentAssignmentErrors}

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/SignOutController.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/SignOutController.scala
@@ -45,5 +45,4 @@ class SignOutController @Inject()(
         .removingFromSession("X-Request-ID", "Session-Id")
     )
   }
-
 }

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/actions/AccountMongoDetailsAction.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/actions/AccountMongoDetailsAction.scala
@@ -35,10 +35,23 @@ case class RequestWithUserDetailsFromSessionAndMongo[A](request: Request[A],
                                                         accountDetailsFromMongo: AccountDetailsFromMongo)
   extends WrappedRequest[A](request)
 
+object RequestWithUserDetailsFromSessionAndMongo{
+  import scala.language.implicitConversions
+  implicit def requestConversion(
+                                  requestWithUserDetailsFromSessionAndMongo: RequestWithUserDetailsFromSessionAndMongo[_])
+  : RequestWithUserDetailsFromSession[_] = {
+    RequestWithUserDetailsFromSession(
+      requestWithUserDetailsFromSessionAndMongo.request,
+      requestWithUserDetailsFromSessionAndMongo.userDetails,
+      requestWithUserDetailsFromSessionAndMongo.sessionID)
+  }
+}
+
 trait AccountMongoDetailsActionTrait
     extends ActionRefiner[RequestWithUserDetailsFromSession, RequestWithUserDetailsFromSessionAndMongo]
 
-class AccountMongoDetailsAction @Inject()(accountCheckOrchestrator: AccountCheckOrchestrator,
+
+  class AccountMongoDetailsAction @Inject()(accountCheckOrchestrator: AccountCheckOrchestrator,
                                           val parser: BodyParsers.Default,
                                           errorHandler: ErrorHandler)(implicit val executionContext: ExecutionContext) extends AccountMongoDetailsActionTrait {
   implicit val baseLogger: Logger = Logger(this.getClass.getName)

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/actions/AuthAction.scala
@@ -43,8 +43,7 @@ case class UserDetailsFromSession(credId: String,
 
 case class RequestWithUserDetailsFromSession[A](request: Request[A],
                                                 userDetails: UserDetailsFromSession,
-                                                sessionID: String)
-    extends WrappedRequest[A](request)
+                                                sessionID: String) extends WrappedRequest[A](request)
 
 trait AuthIdentifierAction
     extends ActionBuilder[RequestWithUserDetailsFromSession, AnyContent]

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/logging/LoggingEvent.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/logging/LoggingEvent.scala
@@ -142,7 +142,7 @@ object LoggingEvent {
   def logIncorrectUserType(
     credentialId: String,
     expectedUserType: List[AccountTypes.Value],
-    actualUserType: Option[AccountTypes.Value]
+    actualUserType: AccountTypes.Value
   ): LoggingEvent = {
     val expectedUserTypeString = expectedUserType.foldLeft[String]("") {
       (a, b) =>
@@ -153,10 +153,8 @@ object LoggingEvent {
         }
     }
 
-    val actualAccountTypeString =
-      actualUserType.fold("no account type found")(_.toString)
     val errorMessage =
-      s"User type of $expectedUserTypeString required but ${actualAccountTypeString} found"
+      s"User type of $expectedUserTypeString required but ${actualUserType.toString} found for $credentialId"
     Warn(
       Event(
         "[MultipleAccountsOrchestrator][checkValidAccountTypeRedirectUrlInCache]",

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/repository/TEASessionCache.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/repository/TEASessionCache.scala
@@ -20,7 +20,7 @@ import com.google.inject.{ImplementedBy, Inject}
 import play.api.libs.json.{Format, JsString}
 import play.api.mvc.AnyContent
 import uk.gov.hmrc.http.cache.client.CacheMap
-import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.actions.RequestWithUserDetailsFromSession
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.actions.{RequestWithUserDetailsFromSession, RequestWithUserDetailsFromSessionAndMongo}
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/services/SilentAssignmentService.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/services/SilentAssignmentService.scala
@@ -24,7 +24,7 @@ import play.api.mvc.AnyContent
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.service.TEAFResult
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.connectors.{EACDConnector, IVConnector, TaxEnrolmentsConnector}
-import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.actions.RequestWithUserDetailsFromSession
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.actions.{RequestWithUserDetailsFromSession, RequestWithUserDetailsFromSessionAndMongo}
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.errors.TaxEnrolmentAssignmentErrors
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.models.IVNinoStoreEntry
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.models.IVNinoStoreEntry._
@@ -69,7 +69,7 @@ class SilentAssignmentService @Inject()(
         }
     }
 
-  def enrolUser()(implicit request: RequestWithUserDetailsFromSession[_],
+  def enrolUser()(implicit request: RequestWithUserDetailsFromSessionAndMongo[_],
                   hc: HeaderCarrier,
                   ec: ExecutionContext): TEAFResult[Unit] = {
     val details = request.userDetails

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/services/UsersGroupsSearchService.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/services/UsersGroupsSearchService.scala
@@ -22,7 +22,7 @@ import play.api.mvc.AnyContent
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.service.TEAFResult
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.connectors.UsersGroupsSearchConnector
-import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.actions.RequestWithUserDetailsFromSession
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.actions.{RequestWithUserDetailsFromSession, RequestWithUserDetailsFromSessionAndMongo}
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.models.AccountDetails
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.repository.SessionKeys.accountDetailsForCredential
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.repository.TEASessionCache
@@ -38,7 +38,7 @@ class UsersGroupsSearchService @Inject()(
   def getAccountDetails(credId: String)(
     implicit ec: ExecutionContext,
     hc: HeaderCarrier,
-    request: RequestWithUserDetailsFromSession[AnyContent]
+    request: RequestWithUserDetailsFromSession[_]
   ): TEAFResult[AccountDetails] = EitherT {
     val key = accountDetailsForCredential(credId)
     sessionCache.getEntry[AccountDetails](key).flatMap {
@@ -52,7 +52,7 @@ class UsersGroupsSearchService @Inject()(
                                                     key: String)(
     implicit ec: ExecutionContext,
     hc: HeaderCarrier,
-    request: RequestWithUserDetailsFromSession[AnyContent]
+    request: RequestWithUserDetailsFromSession[_]
   ): TEAFResult[AccountDetails] = EitherT {
     usersGroupsSearchConnector
       .getUserDetails(credId)

--- a/it/controllers/EnrolledForPTISpec.scala
+++ b/it/controllers/EnrolledForPTISpec.scala
@@ -232,6 +232,7 @@ class EnrolledForPTISpec extends TestHelper with Status {
     "the session cache contains the redirect url" should {
       s"redirect to the redirect url" in {
         await(save[String](sessionId, "redirectURL", UrlPaths.returnUrl))
+        await(save[AccountTypes.Value](sessionId, "ACCOUNT_TYPE", PT_ASSIGNED_TO_CURRENT_USER))
         val authResponse = authoriseResponseJson()
         stubAuthorizePost(OK, authResponse.toString())
         stubPost(s"/write/.*", OK, """{"x":2}""")

--- a/it/controllers/EnrolledPTWithSAOnOtherAccountControllerISpec.scala
+++ b/it/controllers/EnrolledPTWithSAOnOtherAccountControllerISpec.scala
@@ -276,6 +276,7 @@ class EnrolledPTWithSAOnOtherAccountControllerISpec
     "the session cache contains the redirect url" should {
       s"redirect to the redirect url" in {
         await(save[String](sessionId, "redirectURL", UrlPaths.returnUrl))
+        await(save[AccountTypes.Value](sessionId, "ACCOUNT_TYPE", PT_ASSIGNED_TO_CURRENT_USER))
         val authResponse = authoriseResponseJson()
         stubAuthorizePost(OK, authResponse.toString())
         stubPost(s"/write/.*", OK, """{"x":2}""")

--- a/it/controllers/KeepAccessToSAControllerISpec.scala
+++ b/it/controllers/KeepAccessToSAControllerISpec.scala
@@ -439,6 +439,9 @@ class KeepAccessToSAControllerISpec extends TestHelper with Status {
           val authResponse = authoriseResponseJson()
           stubAuthorizePost(OK, authResponse.toString())
           stubPost(s"/write/.*", OK, """{"x":2}""")
+          await(
+            save[AccountTypes.Value](sessionId, "ACCOUNT_TYPE", SA_ASSIGNED_TO_CURRENT_USER)
+          )
 
           val res = buildRequest(urlPath, followRedirects = true)
             .addCookies(DefaultWSCookie("mdtp", authAndSessionCookie))
@@ -473,6 +476,7 @@ class KeepAccessToSAControllerISpec extends TestHelper with Status {
       "render the keepAccessToSA page with errors" in {
         val authResponse = authoriseResponseJson()
         stubAuthorizePost(OK, authResponse.toString())
+        await(save[AccountTypes.Value](sessionId, "ACCOUNT_TYPE", SA_ASSIGNED_TO_CURRENT_USER))
         stubPost(s"/write/.*", OK, """{"x":2}""")
 
         val res = buildRequest(urlPath, followRedirects = true)

--- a/it/helpers/TestITData.scala
+++ b/it/helpers/TestITData.scala
@@ -158,8 +158,6 @@ object TestITData {
     ivNinoStoreEntry4
   )
 
-  // users group search
-
   val usersGroupSearchResponse = UsersGroupResponse(
     obfuscatedUserId = "********6037",
     email = Some("email1@test.com"),

--- a/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/EnrolledPTWithSAOnOtherAccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/EnrolledPTWithSAOnOtherAccountControllerSpec.scala
@@ -24,7 +24,8 @@ import uk.gov.hmrc.auth.core.Enrolments
 import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.{Credentials, Retrieval, ~}
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.actions.RequestWithUserDetailsFromSession
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.AccountTypes
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.actions.{RequestWithUserDetailsFromSession, RequestWithUserDetailsFromSessionAndMongo}
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.errors.{InvalidUserType, UnexpectedResponseFromUsersGroupsSearch}
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.helpers.TestData._
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.helpers.{TestFixture, UrlPaths}
@@ -39,6 +40,7 @@ class EnrolledPTWithSAOnOtherAccountControllerSpec extends TestFixture {
 
   val controller = new EnrolledPTWithSAOnOtherAccountController(
     mockAuthAction,
+    mockAccountMongoDetailsAction,
     mockMultipleAccountsOrchestrator,
     mockTeaSessionCache,
     mcc,
@@ -66,7 +68,7 @@ class EnrolledPTWithSAOnOtherAccountControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .getDetailsForEnrolledPTWithSAOnOtherAccount(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
@@ -75,12 +77,14 @@ class EnrolledPTWithSAOnOtherAccountControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .getSACredentialIfNotFraud(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
           .expects(*, *, *)
           .returning(createInboundResult(None))
+
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val result = controller.view
           .apply(buildFakeRequestWithSessionId("GET", "Not Used"))
@@ -114,7 +118,7 @@ class EnrolledPTWithSAOnOtherAccountControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .getDetailsForEnrolledPTWithSAOnOtherAccount(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
@@ -123,7 +127,7 @@ class EnrolledPTWithSAOnOtherAccountControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .getSACredentialIfNotFraud(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
@@ -133,7 +137,7 @@ class EnrolledPTWithSAOnOtherAccountControllerSpec extends TestFixture {
               Some(accountDetails.copy(userId = "********1234"))
             )
           )
-
+        mockGetAccountTypeSuccess(randomAccountType)
         val result = controller.view
           .apply(buildFakeRequestWithSessionId("GET", "Not Used"))
 
@@ -164,7 +168,7 @@ class EnrolledPTWithSAOnOtherAccountControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .getDetailsForEnrolledPTWithSAOnOtherAccount(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
@@ -172,6 +176,7 @@ class EnrolledPTWithSAOnOtherAccountControllerSpec extends TestFixture {
           .returning(
             createInboundResultError(InvalidUserType(Some(UrlPaths.returnUrl)))
           )
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val result = controller.view
           .apply(buildFakeRequestWithSessionId("GET", "Not Used"))
@@ -197,13 +202,13 @@ class EnrolledPTWithSAOnOtherAccountControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .getDetailsForEnrolledPTWithSAOnOtherAccount(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
           .expects(*, *, *)
           .returning(createInboundResultError(InvalidUserType(None)))
-
+        mockGetAccountTypeSuccess(randomAccountType)
         val res = controller.view
           .apply(buildFakeRequestWithSessionId("GET", "Not Used"))
 
@@ -228,7 +233,7 @@ class EnrolledPTWithSAOnOtherAccountControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .getDetailsForEnrolledPTWithSAOnOtherAccount(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
@@ -236,7 +241,7 @@ class EnrolledPTWithSAOnOtherAccountControllerSpec extends TestFixture {
           .returning(
             createInboundResultError(UnexpectedResponseFromUsersGroupsSearch)
           )
-
+        mockGetAccountTypeSuccess(randomAccountType)
         val res = controller.view
           .apply(buildFakeRequestWithSessionId("GET", "Not Used"))
 

--- a/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/KeepAccessToSAControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/KeepAccessToSAControllerSpec.scala
@@ -24,7 +24,8 @@ import uk.gov.hmrc.auth.core.Enrolments
 import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.{Credentials, Retrieval, ~}
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.actions.RequestWithUserDetailsFromSession
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.AccountTypes
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.actions.{RequestWithUserDetailsFromSession, RequestWithUserDetailsFromSessionAndMongo}
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.errors.{InvalidUserType, UnexpectedResponseFromTaxEnrolments}
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.forms.KeepAccessToSAThroughPTAForm.keepAccessToSAThroughPTAForm
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.helpers.TestData._
@@ -40,6 +41,7 @@ class KeepAccessToSAControllerSpec extends TestFixture {
 
   val controller = new KeepAccessToSAController(
     mockAuthAction,
+    mockAccountMongoDetailsAction,
     mockMultipleAccountsOrchestrator,
     mcc,
     logger,
@@ -66,12 +68,13 @@ class KeepAccessToSAControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .getDetailsForKeepAccessToSA(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
           .expects(*, *, *)
           .returning(createInboundResult(keepAccessToSAThroughPTAForm))
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val result = controller.view
           .apply(buildFakeRequestWithSessionId("GET", "Not Used"))
@@ -108,7 +111,7 @@ class KeepAccessToSAControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .getDetailsForKeepAccessToSA(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
@@ -118,6 +121,7 @@ class KeepAccessToSAControllerSpec extends TestFixture {
               keepAccessToSAThroughPTAForm.fill(KeepAccessToSAThroughPTA(true))
             )
           )
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val result = controller.view
           .apply(buildFakeRequestWithSessionId("GET", "Not Used"))
@@ -154,7 +158,7 @@ class KeepAccessToSAControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .getDetailsForKeepAccessToSA(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
@@ -164,6 +168,7 @@ class KeepAccessToSAControllerSpec extends TestFixture {
               keepAccessToSAThroughPTAForm.fill(KeepAccessToSAThroughPTA(false))
             )
           )
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val result = controller.view
           .apply(buildFakeRequestWithSessionId("GET", "Not Used"))
@@ -198,7 +203,7 @@ class KeepAccessToSAControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .getDetailsForKeepAccessToSA(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
@@ -206,6 +211,7 @@ class KeepAccessToSAControllerSpec extends TestFixture {
           .returning(
             createInboundResultError(InvalidUserType(Some(UrlPaths.returnUrl)))
           )
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val result = controller.view
           .apply(buildFakeRequestWithSessionId("GET", "Not Used"))
@@ -231,12 +237,13 @@ class KeepAccessToSAControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .getDetailsForKeepAccessToSA(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
           .expects(*, *, *)
           .returning(createInboundResultError(InvalidUserType(None)))
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val res = controller.view
           .apply(buildFakeRequestWithSessionId("GET", "Not Used"))
@@ -265,12 +272,13 @@ class KeepAccessToSAControllerSpec extends TestFixture {
 
           (mockMultipleAccountsOrchestrator
             .handleKeepAccessToSAChoice(_: KeepAccessToSAThroughPTA)(
-              _: RequestWithUserDetailsFromSession[AnyContent],
+              _: RequestWithUserDetailsFromSessionAndMongo[_],
               _: HeaderCarrier,
               _: ExecutionContext
             ))
             .expects(KeepAccessToSAThroughPTA(true), *, *, *)
             .returning(createInboundResult(true))
+          mockGetAccountTypeSuccess(randomAccountType)
 
           val res = controller.continue
             .apply(
@@ -300,7 +308,7 @@ class KeepAccessToSAControllerSpec extends TestFixture {
             .returning(Future.successful(retrievalResponse()))
           (mockMultipleAccountsOrchestrator
             .handleKeepAccessToSAChoice(_: KeepAccessToSAThroughPTA)(
-              _: RequestWithUserDetailsFromSession[AnyContent],
+              _: RequestWithUserDetailsFromSessionAndMongo[_],
               _: HeaderCarrier,
               _: ExecutionContext
             ))
@@ -310,6 +318,7 @@ class KeepAccessToSAControllerSpec extends TestFixture {
                 InvalidUserType(Some(UrlPaths.returnUrl))
               )
             )
+          mockGetAccountTypeSuccess(randomAccountType)
 
           val res = controller.continue
             .apply(
@@ -338,12 +347,13 @@ class KeepAccessToSAControllerSpec extends TestFixture {
             .returning(Future.successful(retrievalResponse()))
           (mockMultipleAccountsOrchestrator
             .handleKeepAccessToSAChoice(_: KeepAccessToSAThroughPTA)(
-              _: RequestWithUserDetailsFromSession[AnyContent],
+              _: RequestWithUserDetailsFromSessionAndMongo[_],
               _: HeaderCarrier,
               _: ExecutionContext
             ))
             .expects(KeepAccessToSAThroughPTA(true), *, *, *)
             .returning(createInboundResultError(InvalidUserType(None)))
+          mockGetAccountTypeSuccess(randomAccountType)
 
           val res = controller.continue
             .apply(
@@ -374,12 +384,13 @@ class KeepAccessToSAControllerSpec extends TestFixture {
             .returning(Future.successful(retrievalResponse()))
           (mockMultipleAccountsOrchestrator
             .handleKeepAccessToSAChoice(_: KeepAccessToSAThroughPTA)(
-              _: RequestWithUserDetailsFromSession[AnyContent],
+              _: RequestWithUserDetailsFromSessionAndMongo[_],
               _: HeaderCarrier,
               _: ExecutionContext
             ))
             .expects(KeepAccessToSAThroughPTA(false), *, *, *)
             .returning(createInboundResult(false))
+          mockGetAccountTypeSuccess(randomAccountType)
 
           val res = controller.continue
             .apply(
@@ -409,7 +420,7 @@ class KeepAccessToSAControllerSpec extends TestFixture {
             .returning(Future.successful(retrievalResponse()))
           (mockMultipleAccountsOrchestrator
             .handleKeepAccessToSAChoice(_: KeepAccessToSAThroughPTA)(
-              _: RequestWithUserDetailsFromSession[AnyContent],
+              _: RequestWithUserDetailsFromSessionAndMongo[_],
               _: HeaderCarrier,
               _: ExecutionContext
             ))
@@ -426,6 +437,7 @@ class KeepAccessToSAControllerSpec extends TestFixture {
                 data = Map("select-continue" -> "no")
               )
             )
+          mockGetAccountTypeSuccess(randomAccountType)
 
           status(res) shouldBe SEE_OTHER
           redirectLocation(res) shouldBe Some(UrlPaths.accountCheckPath)
@@ -447,12 +459,13 @@ class KeepAccessToSAControllerSpec extends TestFixture {
             .returning(Future.successful(retrievalResponse()))
           (mockMultipleAccountsOrchestrator
             .handleKeepAccessToSAChoice(_: KeepAccessToSAThroughPTA)(
-              _: RequestWithUserDetailsFromSession[AnyContent],
+              _: RequestWithUserDetailsFromSessionAndMongo[_],
               _: HeaderCarrier,
               _: ExecutionContext
             ))
             .expects(KeepAccessToSAThroughPTA(false), *, *, *)
             .returning(createInboundResultError(InvalidUserType(None)))
+          mockGetAccountTypeSuccess(randomAccountType)
 
           val res = controller.continue
             .apply(
@@ -481,7 +494,7 @@ class KeepAccessToSAControllerSpec extends TestFixture {
             .returning(Future.successful(retrievalResponse()))
           (mockMultipleAccountsOrchestrator
             .handleKeepAccessToSAChoice(_: KeepAccessToSAThroughPTA)(
-              _: RequestWithUserDetailsFromSession[AnyContent],
+              _: RequestWithUserDetailsFromSessionAndMongo[_],
               _: HeaderCarrier,
               _: ExecutionContext
             ))
@@ -489,6 +502,7 @@ class KeepAccessToSAControllerSpec extends TestFixture {
             .returning(
               createInboundResultError(UnexpectedResponseFromTaxEnrolments)
             )
+          mockGetAccountTypeSuccess(randomAccountType)
 
           val res = controller.continue
             .apply(
@@ -515,6 +529,7 @@ class KeepAccessToSAControllerSpec extends TestFixture {
           )(_: HeaderCarrier, _: ExecutionContext))
           .expects(predicates, retrievals, *, *)
           .returning(Future.successful(retrievalResponse()))
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val res = controller.continue
           .apply(

--- a/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/PTEnrolmentOnOtherAccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/PTEnrolmentOnOtherAccountControllerSpec.scala
@@ -25,9 +25,9 @@ import uk.gov.hmrc.auth.core.retrieve.{Credentials, Retrieval, ~}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.AccountTypes
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.AccountTypes.PT_ASSIGNED_TO_OTHER_USER
-import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.actions.RequestWithUserDetailsFromSession
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.actions.{RequestWithUserDetailsFromSession, RequestWithUserDetailsFromSessionAndMongo}
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.errors.{InvalidUserType, NoPTEnrolmentWhenOneExpected}
-import uk.gov.hmrc.taxenrolmentassignmentfrontend.helpers.TestData.{accountDetails, buildFakeRequestWithSessionId, predicates, retrievalResponse, retrievals, saEnrolmentOnly}
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.helpers.TestData.{accountDetails, buildFakeRequestWithSessionId, predicates, randomAccountType, retrievalResponse, retrievals, saEnrolmentOnly}
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.helpers.{TestFixture, UrlPaths}
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.views.html.PTEnrolmentOnAnotherAccount
 
@@ -40,6 +40,7 @@ class PTEnrolmentOnOtherAccountControllerSpec extends TestFixture {
 
   val controller = new PTEnrolmentOnOtherAccountController(
     mockAuthAction,
+    mockAccountMongoDetailsAction,
     mcc,
     mockMultipleAccountsOrchestrator,
     view,
@@ -64,7 +65,7 @@ class PTEnrolmentOnOtherAccountControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .checkValidAccountTypeRedirectUrlInCache(_: List[AccountTypes.Value])(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[AnyContent],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
@@ -73,12 +74,13 @@ class PTEnrolmentOnOtherAccountControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .getPTCredentialDetails(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[AnyContent],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
           .expects(*, *, *)
           .returning(createInboundResult(accountDetails))
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val result = controller.view
           .apply(buildFakeRequestWithSessionId("GET", "Not Used"))
@@ -109,7 +111,7 @@ class PTEnrolmentOnOtherAccountControllerSpec extends TestFixture {
           )
         (mockMultipleAccountsOrchestrator
           .checkValidAccountTypeRedirectUrlInCache(_: List[AccountTypes.Value])(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[AnyContent],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
@@ -118,12 +120,13 @@ class PTEnrolmentOnOtherAccountControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .getPTCredentialDetails(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[AnyContent],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
           .expects(*, *, *)
           .returning(createInboundResult(accountDetails))
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val result = controller.view
           .apply(buildFakeRequestWithSessionId("GET", "Not Used"))
@@ -153,7 +156,7 @@ class PTEnrolmentOnOtherAccountControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .checkValidAccountTypeRedirectUrlInCache(_: List[AccountTypes.Value])(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[AnyContent],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
@@ -161,7 +164,7 @@ class PTEnrolmentOnOtherAccountControllerSpec extends TestFixture {
           .returning(
             createInboundResultError(InvalidUserType(Some(UrlPaths.returnUrl)))
           )
-
+        mockGetAccountTypeSuccess(randomAccountType)
         val result = controller.view
           .apply(buildFakeRequestWithSessionId("GET", "Not Used"))
 
@@ -188,7 +191,7 @@ class PTEnrolmentOnOtherAccountControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .checkValidAccountTypeRedirectUrlInCache(_: List[AccountTypes.Value])(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[AnyContent],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
@@ -197,12 +200,13 @@ class PTEnrolmentOnOtherAccountControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .getPTCredentialDetails(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[AnyContent],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
           .expects(*, *, *)
           .returning(createInboundResultError(NoPTEnrolmentWhenOneExpected))
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val res = controller.view
           .apply(buildFakeRequestWithSessionId("GET", "Not Used"))
@@ -228,12 +232,13 @@ class PTEnrolmentOnOtherAccountControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .checkValidAccountTypeRedirectUrlInCache(_: List[AccountTypes.Value])(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
           .expects(List(PT_ASSIGNED_TO_OTHER_USER), *, *, *)
           .returning(createInboundResultError(InvalidUserType(None)))
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val res = controller.view
           .apply(buildFakeRequestWithSessionId("GET", "Not Used"))

--- a/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/SABlueInterruptControllerSpec.scala
+++ b/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/SABlueInterruptControllerSpec.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.auth.core.retrieve.{Credentials, Retrieval, ~}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.AccountTypes
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.AccountTypes.SA_ASSIGNED_TO_OTHER_USER
-import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.actions.RequestWithUserDetailsFromSession
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.actions.{RequestWithUserDetailsFromSession, RequestWithUserDetailsFromSessionAndMongo}
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.errors.InvalidUserType
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.helpers.TestData._
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.helpers.{TestFixture, UrlPaths}
@@ -41,6 +41,7 @@ class SABlueInterruptControllerSpec extends TestFixture {
   val controller =
     new SABlueInterruptController(
       mockAuthAction,
+      mockAccountMongoDetailsAction,
       mcc,
       mockMultipleAccountsOrchestrator,
       logger,
@@ -65,12 +66,13 @@ class SABlueInterruptControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .checkValidAccountTypeRedirectUrlInCache(_: List[AccountTypes.Value])(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
           .expects(List(SA_ASSIGNED_TO_OTHER_USER), *, *, *)
           .returning(createInboundResult(SA_ASSIGNED_TO_OTHER_USER))
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val result = controller
           .view()
@@ -104,7 +106,7 @@ class SABlueInterruptControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .checkValidAccountTypeRedirectUrlInCache(_: List[AccountTypes.Value])(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
@@ -112,6 +114,7 @@ class SABlueInterruptControllerSpec extends TestFixture {
           .returning(
             createInboundResultError(InvalidUserType(Some(UrlPaths.returnUrl)))
           )
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val result = controller
           .view()
@@ -138,12 +141,13 @@ class SABlueInterruptControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .checkValidAccountTypeRedirectUrlInCache(_: List[AccountTypes.Value])(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
           .expects(List(SA_ASSIGNED_TO_OTHER_USER), *, *, *)
           .returning(createInboundResultError(InvalidUserType(None)))
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val res = controller
           .view()
@@ -172,12 +176,13 @@ class SABlueInterruptControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .checkValidAccountTypeRedirectUrlInCache(_: List[AccountTypes.Value])(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
           .expects(List(SA_ASSIGNED_TO_OTHER_USER), *, *, *)
           .returning(createInboundResult(SA_ASSIGNED_TO_OTHER_USER))
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val result = controller
           .continue()
@@ -206,7 +211,7 @@ class SABlueInterruptControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .checkValidAccountTypeRedirectUrlInCache(_: List[AccountTypes.Value])(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
@@ -214,6 +219,7 @@ class SABlueInterruptControllerSpec extends TestFixture {
           .returning(
             createInboundResultError(InvalidUserType(Some(UrlPaths.returnUrl)))
           )
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val result = controller
           .continue()
@@ -240,12 +246,13 @@ class SABlueInterruptControllerSpec extends TestFixture {
 
         (mockMultipleAccountsOrchestrator
           .checkValidAccountTypeRedirectUrlInCache(_: List[AccountTypes.Value])(
-            _: RequestWithUserDetailsFromSession[AnyContent],
+            _: RequestWithUserDetailsFromSessionAndMongo[_],
             _: HeaderCarrier,
             _: ExecutionContext
           ))
           .expects(List(SA_ASSIGNED_TO_OTHER_USER), *, *, *)
           .returning(createInboundResultError(InvalidUserType(None)))
+        mockGetAccountTypeSuccess(randomAccountType)
 
         val result = controller
           .continue()

--- a/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/actions/AccountMongoDetailsActionSpec.scala
+++ b/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/actions/AccountMongoDetailsActionSpec.scala
@@ -21,7 +21,8 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.{Enrolment, Enrolments}
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.taxenrolmentassignmentfrontend.AccountTypes.PT_ASSIGNED_TO_CURRENT_USER
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.AccountTypes.{PT_ASSIGNED_TO_CURRENT_USER, SINGLE_ACCOUNT}
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.actions.RequestWithUserDetailsFromSessionAndMongo.requestConversion
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.errors.UnexpectedErrorWhenGettingUserType
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.helpers.TestFixture
 
@@ -67,5 +68,16 @@ class AccountMongoDetailsActionSpec extends TestFixture {
       contentAsString(res) should include("enrolmentError.title")
     }
   }
+  "RequestWithUserDetailsFromSessionAndMongo.requestConversion" should {
+    "convert correctly" in {
+      val requestWithUserDetailsFromSession = RequestWithUserDetailsFromSession(
+        FakeRequest(), UserDetailsFromSession("foo","bar","wizz", Enrolments(Set.empty[Enrolment]), true, true), "foo")
 
+      requestConversion(RequestWithUserDetailsFromSessionAndMongo(
+        requestWithUserDetailsFromSession.request,
+        requestWithUserDetailsFromSession.userDetails,
+        requestWithUserDetailsFromSession.sessionID,
+        AccountDetailsFromMongo(SINGLE_ACCOUNT))) shouldBe requestWithUserDetailsFromSession
+    }
+  }
 }

--- a/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/helpers/TestData.scala
+++ b/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/helpers/TestData.scala
@@ -23,6 +23,7 @@ import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{allEnrolments, credentials, groupIdentifier, nino}
 import uk.gov.hmrc.auth.core.retrieve.{Credentials, Retrieval, ~}
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.AccountTypes
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.AccountTypes.{MULTIPLE_ACCOUNTS, PT_ASSIGNED_TO_CURRENT_USER, PT_ASSIGNED_TO_OTHER_USER, SA_ASSIGNED_TO_CURRENT_USER, SA_ASSIGNED_TO_OTHER_USER, SINGLE_ACCOUNT}
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.actions.UserDetailsFromSession
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.models.{EACDEnrolment => _, _}
@@ -74,7 +75,7 @@ object TestData {
     )
   )
 
-  //AuthAction
+ val randomAccountType: AccountTypes.Value = SINGLE_ACCOUNT
   val predicates: Predicate =
     AuthProviders(GovernmentGateway) and ConfidenceLevel.L200
 


### PR DESCRIPTION
I think this pr has highlighted that we should get everything from mongo at the start of controller call in an action and not get everything by key individually, as we do too many calls to mongo..
We should raise tech debt for that.

🦀  I still havent run this against the journey tests, I still haven't setup my local environment (sorry). please run journey tests before merging.. 🦀 
I will probably have a big rebase after tawandas pr is merged