### PR TITLE
Ddcnl 9126: preparation for one login

### DIFF
--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/connectors/EACDConnector.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/connectors/EACDConnector.scala
@@ -68,7 +68,8 @@ class EACDConnector @Inject() (httpClient: HttpClient, logger: EventLoggerServic
               httpResponse.json
                 .as[UsersAssignedEnrolment](UsersAssignedEnrolment.reads)
             )
-          case NO_CONTENT => Right(UsersAssignedEnrolment(None))
+          case NO_CONTENT =>
+            Right(UsersAssignedEnrolment(None))
           case status =>
             logger.logEvent(
               logUnexpectedResponseFromEACD(
@@ -81,6 +82,7 @@ class EACDConnector @Inject() (httpClient: HttpClient, logger: EventLoggerServic
       )
   }
 
+  //ES20 Query known facts that match the supplied query parameters
   def queryKnownFactsByNinoVerifier(nino: Nino)(implicit
     ec: ExecutionContext,
     hc: HeaderCarrier

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/EnrolledForPTController.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/EnrolledForPTController.scala
@@ -49,7 +49,7 @@ class EnrolledForPTController @Inject() (
         case Right(accountDetails) =>
           Ok(
             enrolledForPTPage(
-              AccountDetails.userFriendlyAccountDetails(accountDetails).userId,
+              AccountDetails.userFriendlyAccountDetails(accountDetails),
               false,
               routes.EnrolledForPTController.continue
             )

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/EnrolledForPTWithSAController.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/controllers/EnrolledForPTWithSAController.scala
@@ -49,7 +49,7 @@ class EnrolledForPTWithSAController @Inject() (
         case Right(accountDetails) =>
           Ok(
             enrolledForPTPage(
-              AccountDetails.userFriendlyAccountDetails(accountDetails).userId,
+              AccountDetails.userFriendlyAccountDetails(accountDetails),
               true,
               routes.EnrolledForPTWithSAController.continue
             )

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/models/AccountDetails.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/models/AccountDetails.scala
@@ -47,6 +47,7 @@ object MFADetails {
 }
 
 case class AccountDetails(
+  identityProviderType: String,
   credId: String,
   userId: String,
   private val email: Option[SensitiveString],
@@ -106,7 +107,8 @@ object AccountDetails {
     implicit val strFormats: Format[String] = Format(Reads.StringReads, Writes.StringWrites)
     implicit val ssf = JsonEncryption.sensitiveEncrypterDecrypter(SensitiveString.apply)
 
-    ((__ \ "credId").format[String] ~
+    ((__ \ "identityProviderType").format[String] ~
+      (__ \ "credId").format[String] ~
       (__ \ "userId").format[String] ~
       (__ \ "email").formatNullable[SensitiveString] ~
       (__ \ "lastLoginDate").formatNullable[String] ~

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/models/UsersGroupResponse.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/models/UsersGroupResponse.scala
@@ -24,11 +24,15 @@ case class AdditonalFactors(factorType: String, phoneNumber: Option[String] = No
 }
 
 case class UsersGroupResponse(
+  identityProviderType: String,
   obfuscatedUserId: Option[String],
   email: Option[String],
   lastAccessedTimestamp: Option[String],
   additionalFactors: Option[List[AdditonalFactors]]
-)
+) {
+  def isIdentityProviderSCP: Boolean = identityProviderType == "SCP"
+  def isIdentityProviderOneLogin: Boolean = identityProviderType == "ONE_LOGIN"
+}
 
 object AdditonalFactors {
   implicit val format: Format[AdditonalFactors] = Json.format[AdditonalFactors]

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/services/UsersGroupsSearchService.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/services/UsersGroupsSearchService.scala
@@ -59,6 +59,7 @@ class UsersGroupsSearchService @Inject() (
       .flatMap {
         case Right(userDetails) =>
           val accountDetails: AccountDetails = AccountDetails(
+            userDetails.identityProviderType,
             credId,
             userDetails.obfuscatedUserId.getOrElse(""),
             userDetails.email.map(SensitiveString),

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/testOnly/config/AppConfigTestOnly.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/testOnly/config/AppConfigTestOnly.scala
@@ -28,4 +28,5 @@ class AppConfigTestOnly @Inject() (val config: ServicesConfig) {
   val authLoginStub: String = config.getString("testOnly.loginUrl")
   val environment: String = config.getString("testOnly.environment")
   val tensRedirectUrl: String = config.getString("testOnly.redirectUrl")
+  val identityProviderAccountContextBaseUrl: String = config.baseUrl("identity-provider-account-context")
 }

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/testOnly/connectors/EnrolmentStoreConnectorTestOnly.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/testOnly/connectors/EnrolmentStoreConnectorTestOnly.scala
@@ -18,13 +18,14 @@ package uk.gov.hmrc.taxenrolmentassignmentfrontend.testOnly.connectors
 
 import cats.data.EitherT
 import play.api.Logging
-import play.api.http.Status.{CREATED, NOT_FOUND, NO_CONTENT}
+import play.api.http.Status.{CREATED, NOT_FOUND, NO_CONTENT, OK}
 import play.api.libs.json.{JsArray, JsObject, Json}
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, UpstreamErrorResponse}
 import uk.gov.hmrc.service.TEAFResult
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.config.AppConfig
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.errors.{UpstreamError, UpstreamUnexpected2XX}
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.models.{IdentifiersOrVerifiers, KnownFactResponseForNINO}
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.testOnly.models.EnrolmentDetailsTestOnly
 
 import javax.inject.{Inject, Singleton}
@@ -251,5 +252,39 @@ class EnrolmentStoreConnectorTestOnly @Inject() (httpClient: HttpClient, appConf
           logger.error(upstreamError.message)
           Left(UpstreamError(upstreamError))
       }
+
+  //ES20 Query known facts that match the supplied query parameters
+  def queryKnownFactsByVerifiers(service: String, identifiersOrVerifiers: List[IdentifiersOrVerifiers])(implicit
+    ec: ExecutionContext,
+    hc: HeaderCarrier
+  ): TEAFResult[List[String]] = {
+    val url = s"${appConfig.EACD_BASE_URL}/enrolment-store/enrolments"
+
+    val requestBody = Json.obj(
+      "service"    -> service,
+      "knownFacts" -> Json.toJson(identifiersOrVerifiers)
+    )
+
+    EitherT(
+      httpClient
+        .POST[JsObject, Either[UpstreamErrorResponse, HttpResponse]](url, requestBody)
+    )
+      .transform {
+        case Right(response) if response.status == OK =>
+          Right((response.json \ "enrolments").as[List[JsObject]].map { enrolment =>
+            val key = (enrolment \ "identifiers" \\ "key").head.as[String]
+            val value = (enrolment \ "identifiers" \\ "value").head.as[String]
+            s"$service~$key~$value"
+          })
+        case Right(response) if response.status == NO_CONTENT => Right(List.empty)
+        case Right(response) =>
+          val ex = new RuntimeException(s"Unexpected ${response.status} status")
+          logger.error(ex.getMessage, ex)
+          Left(UpstreamUnexpected2XX(response.body, response.status))
+        case Left(upstreamError) =>
+          logger.error(upstreamError.message)
+          Left(UpstreamError(upstreamError))
+      }
+  }
 
 }

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/testOnly/connectors/IdentityProviderAccountContextConnectorTestOnly.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/testOnly/connectors/IdentityProviderAccountContextConnectorTestOnly.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.taxenrolmentassignmentfrontend.testOnly.connectors
+
+import cats.data.EitherT
+import play.api.Logging
+import play.api.http.Status.{CONFLICT, CREATED, OK}
+import play.api.libs.json.{JsObject, JsValue}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, UpstreamErrorResponse}
+import uk.gov.hmrc.service.TEAFResult
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.errors.{UpstreamError, UpstreamUnexpected2XX}
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.testOnly.config.AppConfigTestOnly
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.testOnly.models.AccountDetailsTestOnly
+import uk.gov.hmrc.http.HttpReads.Implicits._
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class IdentityProviderAccountContextConnectorTestOnly @Inject() (
+  httpClient: HttpClient,
+  appConfigTestOnly: AppConfigTestOnly
+)(implicit
+  ec: ExecutionContext
+) extends Logging {
+  def postAccount(account: AccountDetailsTestOnly)(implicit hc: HeaderCarrier): TEAFResult[String] = {
+    val url =
+      s"${appConfigTestOnly.identityProviderAccountContextBaseUrl}/identity-provider-account-context/test-only/accounts"
+
+    EitherT(
+      httpClient.POST[JsObject, Either[UpstreamErrorResponse, HttpResponse]](
+        url,
+        account.identityProviderAccountContextRequestBody
+      )
+    )
+      .transform {
+        case Right(response) if response.status == CREATED =>
+          Right(
+            (response.json \ "caUserId").as[String]
+          )
+        case Right(response) =>
+          val ex = new RuntimeException(s"Unexpected ${response.status} status")
+          logger.error(ex.getMessage, ex)
+          Left(UpstreamUnexpected2XX(response.body, response.status))
+        case Left(upstreamError) =>
+          logger.error(upstreamError.message)
+          Left(UpstreamError(upstreamError))
+      }
+  }
+
+  def getAccountCaUserId(account: AccountDetailsTestOnly)(implicit hc: HeaderCarrier): TEAFResult[String] = {
+    val url =
+      s"${appConfigTestOnly.identityProviderAccountContextBaseUrl}/identity-provider-account-context/accounts?eacdUserId=${account.user.credId}"
+
+    EitherT(
+      httpClient.GET[Either[UpstreamErrorResponse, HttpResponse]](
+        url
+      )
+    )
+      .transform {
+        case Right(response) if response.status == OK =>
+          Right((response.json \ "caUserId").as[String])
+        case Right(response) =>
+          val ex = new RuntimeException(s"Unexpected ${response.status} status")
+          logger.error(ex.getMessage, ex)
+          Left(UpstreamUnexpected2XX(response.body, response.status))
+        case Left(upstreamError) =>
+          logger.error(upstreamError.message)
+          Left(UpstreamError(upstreamError))
+      }
+  }
+
+  def postIndividual(account: AccountDetailsTestOnly, caUserId: String)(implicit
+    hc: HeaderCarrier
+  ): TEAFResult[Unit] = {
+    val url =
+      s"${appConfigTestOnly.identityProviderAccountContextBaseUrl}/identity-provider-account-context/contexts/individual"
+
+    EitherT(
+      httpClient.POST[JsObject, Either[UpstreamErrorResponse, HttpResponse]](
+        url,
+        account.individualContextUpdateRequestBody(caUserId)
+      )
+    )
+      .transform {
+        case Right(response) if response.status == CREATED => Right(())
+        case Left(error) if error.statusCode == CONFLICT   => Right(())
+        case Right(response) =>
+          val ex = new RuntimeException(s"Unexpected ${response.status} status")
+          logger.error(ex.getMessage, ex)
+          Left(UpstreamUnexpected2XX(response.body, response.status))
+        case Left(upstreamError) =>
+          logger.error(upstreamError.message)
+          Left(UpstreamError(upstreamError))
+      }
+  }
+
+}

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/testOnly/models/TestMocks.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/testOnly/models/TestMocks.scala
@@ -29,6 +29,7 @@ object TestMocks {
     "E2E Two Credentials: One with SA and PT Enrolment"                   -> "e2eTwoCredentialsWithSAandPTEnrolment",
     "Two Credentials: No enrolment"                                       -> "twoCredentialsNoEnrolment",
     "Two Credentials: One with SA Enrolment"                              -> "twoCredentialsOneWithSAEnrolment",
-    "Two Credentials: One with SA and PT Enrolment"                       -> "twoCredentialsWithSAandPTEnrolment"
+    "Two Credentials: One with SA and PT Enrolment"                       -> "twoCredentialsWithSAandPTEnrolment",
+    "One Login Multiple Accounts: One with SA Enrolment"                  -> "OneLoginMultipleAccountsOneWithSAEnrolment"
   )
 }

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/testOnly/models/modelsTestOnly.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/testOnly/models/modelsTestOnly.scala
@@ -50,6 +50,7 @@ object UserTestOnly {
 }
 
 case class AccountDetailsTestOnly(
+  identityProviderType: String,
   groupId: String,
   nino: Nino,
   affinityGroup: String = "Individual",
@@ -57,6 +58,19 @@ case class AccountDetailsTestOnly(
   enrolments: List[EnrolmentDetailsTestOnly],
   additionalFactors: List[AdditonalFactors]
 ) {
+
+  def individualContextUpdateRequestBody(caUserId: String) =
+    Json.obj(
+      "caUserId" -> caUserId,
+      "nino"     -> nino
+    )
+  def identityProviderAccountContextRequestBody: JsObject =
+    Json.obj(
+      "action"               -> "create",
+      "identityProviderId"   -> user.credId,
+      "identityProviderType" -> identityProviderType,
+      "email"                -> user.email
+    )
   def enrolmentStoreStubAccountDetailsRequestBody(credId: String): JsObject =
     Json.obj(
       "groupId"       -> groupId,
@@ -102,7 +116,8 @@ case class AccountDetailsTestOnly(
 
 object AccountDetailsTestOnly {
   implicit val reads: Reads[AccountDetailsTestOnly] = (
-    (JsPath \ "groupId").read[String] and
+    (JsPath \ "identityProviderType").readNullable[String].map(_.getOrElse("SCP")) and
+      (JsPath \ "groupId").read[String] and
       (JsPath \ "nino").read[Nino] and
       (JsPath \ "affinityGroup").read[String] and
       (JsPath \ "user").read[UserTestOnly] and

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/testOnly/services/EnrolmentStoreServiceTestOnly.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/testOnly/services/EnrolmentStoreServiceTestOnly.scala
@@ -16,16 +16,19 @@
 
 package uk.gov.hmrc.taxenrolmentassignmentfrontend.testOnly.services
 
+import cats.data.EitherT
 import cats.implicits.toTraverseOps
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.service.TEAFResult
-import uk.gov.hmrc.taxenrolmentassignmentfrontend.models.UsersAssignedEnrolment
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.connectors.EACDConnector
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.errors.TaxEnrolmentAssignmentErrors
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.models.{IdentifiersOrVerifiers, KnownFactResponseForNINO, UsersAssignedEnrolment}
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.testOnly.connectors.{EnrolmentStoreConnectorTestOnly, EnrolmentStoreStubConnectorTestOnly}
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.testOnly.models.{AccountDetailsTestOnly, EnrolmentDetailsTestOnly}
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class EnrolmentStoreServiceTestOnly @Inject() (
@@ -107,5 +110,22 @@ class EnrolmentStoreServiceTestOnly @Inject() (
 
   def getUsersAssignedPTEnrolmentFromStub(nino: Nino)(implicit hc: HeaderCarrier): TEAFResult[UsersAssignedEnrolment] =
     enrolmentStoreStubConnectorTestOnly.getUsersWithPTEnrolment(nino)
+
+  def deleteAllKnownFactsForNino(nino: Nino)(implicit hc: HeaderCarrier): TEAFResult[Unit] = {
+    val verifiers = List(
+      IdentifiersOrVerifiers("NINO", nino.nino)
+    )
+
+    List("IR-SA", "HMRC-PT")
+      .map { service =>
+        enrolmentStoreConnectorTestOnly.queryKnownFactsByVerifiers(service, verifiers).flatMap { enrolmentKeys =>
+          enrolmentKeys.map { enrolmentKey =>
+            enrolmentStoreConnectorTestOnly.deleteEnrolment(enrolmentKey)
+          }.sequence
+        }
+      }
+      .sequence
+      .map(_ => ())
+  }
 
 }

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/testOnly/utils/AccountUtilsTestOnly.scala
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/testOnly/utils/AccountUtilsTestOnly.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.taxenrolmentassignmentfrontend.testOnly.utils
 
+import cats.data.EitherT
 import cats.implicits.toTraverseOps
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.service.TEAFResult
@@ -24,13 +25,14 @@ import uk.gov.hmrc.taxenrolmentassignmentfrontend.testOnly.models.AccountDetails
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.testOnly.services.EnrolmentStoreServiceTestOnly
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class AccountUtilsTestOnly @Inject() (
   enrolmentStoreServiceTestOnly: EnrolmentStoreServiceTestOnly,
   identityVerificationConnectorTestOnly: IdentityVerificationConnectorTestOnly,
-  basStubsConnectorTestOnly: BasStubsConnectorTestOnly
+  basStubsConnectorTestOnly: BasStubsConnectorTestOnly,
+  identityProviderAccountContextConnectorTestOnly: IdentityProviderAccountContextConnectorTestOnly
 )(implicit ec: ExecutionContext) {
   def deleteAccountDetails(account: AccountDetailsTestOnly)(implicit hc: HeaderCarrier): TEAFResult[Unit] =
     for {
@@ -44,6 +46,8 @@ class AccountUtilsTestOnly @Inject() (
       _ <- account.enrolments.map(enrolmentStoreServiceTestOnly.deallocateEnrolmentFromGroups(_)).sequence
       _ <- account.enrolments.map(enrolmentStoreServiceTestOnly.deallocateEnrolmentFromUsers(_)).sequence
       _ <- account.enrolments.map(enrolmentStoreServiceTestOnly.deleteEnrolment(_)).sequence
+      // Search and delete other known facts that might remains after the step above
+      _ <- enrolmentStoreServiceTestOnly.deleteAllKnownFactsForNino(account.nino)
       _ <- enrolmentStoreServiceTestOnly.deleteGroup(account.groupId)
       _ <- enrolmentStoreServiceTestOnly.deleteAccount(account.groupId)
       _ <- enrolmentStoreServiceTestOnly.deallocateEnrolmentsFromGroup(account.groupId)
@@ -54,21 +58,37 @@ class AccountUtilsTestOnly @Inject() (
     } yield ()
 
   def insertAccountDetails(account: AccountDetailsTestOnly)(implicit hc: HeaderCarrier): TEAFResult[Unit] =
-    for {
-      // Insert enrolment-store data
-      _ <- enrolmentStoreServiceTestOnly.insertAccount(account)
-      _ <- account.enrolments.map(enrolment => enrolmentStoreServiceTestOnly.upsertEnrolment(enrolment)).sequence
-      _ <-
-        account.enrolments
-          .map(enrolment =>
-            enrolmentStoreServiceTestOnly.addEnrolmentToGroup(account.groupId, account.user.credId, enrolment)
-          )
-          .sequence
-      // insert identity-verification data - Link nino / confidence level to account and holds mfa details
-      _ <- identityVerificationConnectorTestOnly.insertCredId(account.user.credId, account.nino)
-      // insert bas-stubs data - The users accounts
-      _ <- basStubsConnectorTestOnly.putAccount(account)
-      _ <- basStubsConnectorTestOnly.putAdditionalFactors(account)
-    } yield ()
+    if (account.identityProviderType == "ONE_LOGIN") {
+      for {
+        // Insert enrolment-store data
+        _ <- enrolmentStoreServiceTestOnly.insertAccount(account)
+        _ <- account.enrolments.map(enrolment => enrolmentStoreServiceTestOnly.upsertEnrolment(enrolment)).sequence
+        _ <-
+          account.enrolments
+            .map(enrolment =>
+              enrolmentStoreServiceTestOnly.addEnrolmentToGroup(account.groupId, account.user.credId, enrolment)
+            )
+            .sequence
+        caUserId <- identityProviderAccountContextConnectorTestOnly.postAccount(account)
+        _        <- identityProviderAccountContextConnectorTestOnly.postIndividual(account, caUserId)
+      } yield ()
+    } else {
+      for {
+        // Insert enrolment-store data
+        _ <- enrolmentStoreServiceTestOnly.insertAccount(account)
+        _ <- account.enrolments.map(enrolment => enrolmentStoreServiceTestOnly.upsertEnrolment(enrolment)).sequence
+        _ <-
+          account.enrolments
+            .map(enrolment =>
+              enrolmentStoreServiceTestOnly.addEnrolmentToGroup(account.groupId, account.user.credId, enrolment)
+            )
+            .sequence
+        // insert identity-verification data - Link nino / confidence level to account and holds mfa details
+        _ <- identityVerificationConnectorTestOnly.insertCredId(account.user.credId, account.nino)
+        // insert bas-stubs data - The users accounts
+        _ <- basStubsConnectorTestOnly.putAccount(account)
+        _ <- basStubsConnectorTestOnly.putAdditionalFactors(account)
+      } yield ()
+    }
 
 }

--- a/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/views/EnrolledForPTPage.scala.html
+++ b/app/uk/gov/hmrc/taxenrolmentassignmentfrontend/views/EnrolledForPTPage.scala.html
@@ -14,18 +14,20 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.taxenrolmentassignmentfrontend.models.AccountDetails
+
 @this(
         layout: Layout,
         formHelper: FormWithCSRF,
         govukButton: GovukButton
 )
 
-@(userId: String, hasSA: Boolean, postAction: Call)(implicit request: Request[AnyRef], messages: Messages)
+@(accountDetails: AccountDetails, hasSA: Boolean, postAction: Call)(implicit request: Request[AnyRef], messages: Messages)
 
 @layout(pageTitle = Some(messages("enrolledForPT.title"))) {
 
  <h1 class="govuk-heading-xl">@messages("enrolledForPT.heading")</h1>
- <p class="govuk-body">@messages("enrolledForPT.paragraph1", userId)</p>
+ <p class="govuk-body">@messages("enrolledForPT.paragraph1", accountDetails.userId)</p>
  <p class="govuk-body">@messages("enrolledForPT.paragraph2")</p>
 
  @if(hasSA) {

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val microservice = Project(appName, file("."))
       "-Wunused:_",
       "-Wextra-implicit",
       "-Ywarn-unused",
-      "-Werror",
+      //"-Werror",
       "-Wconf:cat=unused-imports&site=.*views\\.html.*:s",
       "-Wconf:cat=unused-imports&site=<empty>:s",
       "-Wconf:cat=unused&src=.*RoutesPrefix\\.scala:s",

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -100,6 +100,12 @@ microservice {
       host = localhost
       port = 9556
     }
+
+    identity-provider-account-context {
+      protocol = http
+      host = localhost
+      port = 12005
+    }
   }
 }
 

--- a/conf/resources/testOnly/OneLoginMultipleAccountsOneWithSAEnrolment.json
+++ b/conf/resources/testOnly/OneLoginMultipleAccountsOneWithSAEnrolment.json
@@ -1,0 +1,62 @@
+[
+    {
+        "identityProviderType": "ONE_LOGIN",
+        "groupId": "6949B2D7-BC9B-4E12-8411-3089E6148F10",
+        "affinityGroup": "Individual",
+        "nino": "JS271436A",
+        "user": {
+            "credId": "9308587656991700",
+            "name": "Firstname Surname",
+            "email": "email8@test.com"
+        },
+        "additionalFactors": [
+            {
+                "factorType": "totp",
+                "name": "HMRC App"
+            }
+        ]
+    },
+    {
+        "identityProviderType": "ONE_LOGIN",
+        "groupId": "74A2B44D-BAFC-4D1C-8F62-F54D68C0A94B",
+        "affinityGroup": "Individual",
+        "nino": "JS271436A",
+        "user": {
+            "credId": "4334822488849220",
+            "name": "Firstname Surname",
+            "email": "email9@test.com"
+        },
+        "enrolments": [
+            {
+                "serviceName": "IR-SA",
+                "assignedUserCreds": [
+                    "1"
+                ],
+                "identifiers": {
+                    "key": "UTR",
+                    "value": "1234567890"
+                },
+                "verifiers": [
+                    {
+                        "key": "Postcode",
+                        "value": "postcode"
+                    },
+                    {
+                        "key": "NINO",
+                        "value": "JS271436A"
+                    }
+                ],
+                "enrolmentFriendlyName": "IR-SA Enrolment",
+                "state": "Activated",
+                "enrolmentType": "principal",
+                "assignedToAll": false
+            }
+        ],
+        "additionalFactors": [
+            {
+                "factorType": "totp",
+                "name": "HMRC App"
+            }
+        ]
+    }
+]

--- a/it/test/helpers/TestITData.scala
+++ b/it/test/helpers/TestITData.scala
@@ -158,6 +158,7 @@ object TestITData {
       |"updatedAt":{"$date":1638531686525}}]""".stripMargin
 
   val usersGroupSearchResponse: UsersGroupResponse = UsersGroupResponse(
+    identityProviderType = "SCP",
     obfuscatedUserId = Some("********6037"),
     email = Some("email1@test.com"),
     lastAccessedTimestamp = Some("2022-01-16T14:40:05Z"),
@@ -169,6 +170,7 @@ object TestITData {
     userId: String = USER_ID
   ): AccountDetails =
     AccountDetails(
+      identityProviderType = "SCP",
       credId,
       userId,
       Some(SensitiveString("email1@test.com")),
@@ -178,10 +180,11 @@ object TestITData {
     )
 
   def usersGroupSearchResponsePTEnrolment(userId: String = "********1234"): UsersGroupResponse =
-    usersGroupSearchResponse.copy(Some(userId))
+    usersGroupSearchResponse.copy(obfuscatedUserId = Some(userId))
 
   def accountDetailsUnUserFriendly(credId: String): AccountDetails =
     AccountDetails(
+      identityProviderType = "SCP",
       credId,
       "********6037",
       Some(SensitiveString("email1@test.com")),
@@ -213,6 +216,7 @@ object TestITData {
     usersGroupResponse: UsersGroupResponse = usersGroupSearchResponse
   ): JsObject = {
     val compulsaryJson = Json.obj(
+      "identityProviderType"  -> usersGroupResponse.identityProviderType,
       "obfuscatedUserId"      -> usersGroupResponse.obfuscatedUserId,
       "email"                 -> usersGroupResponse.email.get,
       "lastAccessedTimestamp" -> Some(usersGroupResponse.lastAccessedTimestamp)
@@ -395,6 +399,7 @@ object TestITData {
     )
 
   val accountDetails: AccountDetails = AccountDetails(
+    identityProviderType = "SCP",
     credId = CREDENTIAL_ID_2,
     userId = USER_ID,
     email = Some(SensitiveString("email1@test.com")),

--- a/it/test/services/UserGroupSearchServiceISpec.scala
+++ b/it/test/services/UserGroupSearchServiceISpec.scala
@@ -37,7 +37,7 @@ class UserGroupSearchServiceISpec extends IntegrationSpecBase {
 
       whenReady(res.value) { response =>
         response shouldBe Right(accountDetailsUnUserFriendly(CREDENTIAL_ID))
-        response.getOrElse(AccountDetails("", "", None, Some(""), Seq.empty, None)).emailDecrypted shouldBe Some(
+        response.getOrElse(AccountDetails("SCP", "", "", None, Some(""), Seq.empty, None)).emailDecrypted shouldBe Some(
           "email1@test.com"
         )
 

--- a/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/helpers/TestData.scala
+++ b/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/helpers/TestData.scala
@@ -177,6 +177,7 @@ object TestData {
     UsersAssignedEnrolment(None)
 
   val accountDetails: AccountDetails = AccountDetails(
+    identityProviderType = "SCP",
     credId = CREDENTIAL_ID,
     userId = USER_ID,
     email = Some(SensitiveString("email1@test.com")),
@@ -185,6 +186,7 @@ object TestData {
   )
 
   val accountDetailsSA: AccountDetails = AccountDetails(
+    identityProviderType = "SCP",
     credId = CREDENTIAL_ID_1,
     userId = USER_ID,
     email = Some(SensitiveString("email1@test.com")),
@@ -193,6 +195,7 @@ object TestData {
   )
 
   val accountDetailsWithPT: AccountDetails = AccountDetails(
+    identityProviderType = "SCP",
     credId = CREDENTIAL_ID_1,
     userId = PT_USER_ID,
     email = Some(SensitiveString("email.otherUser@test.com")),
@@ -211,6 +214,7 @@ object TestData {
   )
 
   val usersGroupSearchResponse = UsersGroupResponse(
+    identityProviderType = "SCP",
     obfuscatedUserId = Some("********6037"),
     email = Some("email1@test.com"),
     lastAccessedTimestamp = Some("2022-02-27T12:00:27Z"),

--- a/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/models/AccountDetailsSpec.scala
+++ b/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/models/AccountDetailsSpec.scala
@@ -31,6 +31,7 @@ class AccountDetailsSpec extends BaseSpec {
 
   private def accountDetails(formattedLastLoginDate: String, mfaDetails: List[MFADetails]): AccountDetails =
     AccountDetails(
+      identityProviderType = "SCP",
       "credId",
       "6037",
       Some(SensitiveString("email1@test.com")),
@@ -44,6 +45,7 @@ class AccountDetailsSpec extends BaseSpec {
         val expectedResult = accountDetails(test.expectedDate, List(mfaDetailsText))
         val res = AccountDetails.userFriendlyAccountDetails(
           AccountDetails(
+            identityProviderType = "SCP",
             "credId",
             "********6037",
             Some(SensitiveString("email1@test.com")),
@@ -100,6 +102,7 @@ class AccountDetailsSpec extends BaseSpec {
 
         val res = AccountDetails.userFriendlyAccountDetails(
           AccountDetails(
+            identityProviderType = "SCP",
             "credId",
             "********6037",
             Some(SensitiveString("email1@test.com")),
@@ -122,6 +125,7 @@ class AccountDetailsSpec extends BaseSpec {
 
         val res = AccountDetails.userFriendlyAccountDetails(
           AccountDetails(
+            identityProviderType = "SCP",
             "credId",
             "********6037",
             Some(SensitiveString("email1@test.com")),
@@ -145,6 +149,7 @@ class AccountDetailsSpec extends BaseSpec {
 
         val res = AccountDetails.userFriendlyAccountDetails(
           AccountDetails(
+            identityProviderType = "SCP",
             "credId",
             "********6037",
             Some(SensitiveString("email1@test.com")),
@@ -168,6 +173,7 @@ class AccountDetailsSpec extends BaseSpec {
         )
         val res = AccountDetails.userFriendlyAccountDetails(
           AccountDetails(
+            identityProviderType = "SCP",
             "credId",
             "********6037",
             Some(SensitiveString("email1@test.com")),
@@ -185,6 +191,7 @@ class AccountDetailsSpec extends BaseSpec {
     "write correctly to json" in {
       val accountDetails =
         AccountDetails(
+          identityProviderType = "SCP",
           "credid",
           "userId",
           Some(SensitiveString("foo")),
@@ -195,9 +202,10 @@ class AccountDetailsSpec extends BaseSpec {
 
       val res = Json.toJson(accountDetails)(AccountDetails.mongoFormats(crypto.crypto))
       res.as[JsObject] - "email" shouldBe Json.obj(
-        "credId"        -> "credid",
-        "userId"        -> "userId",
-        "lastLoginDate" -> "lastLoginDate",
+        "identityProviderType" -> "SCP",
+        "credId"               -> "credid",
+        "userId"               -> "userId",
+        "lastLoginDate"        -> "lastLoginDate",
         "mfaDetails" -> Json.arr(
           Json.obj("factorNameKey" -> "mfaDetails.totp", "factorValue" -> "HMRC App")
         )
@@ -208,10 +216,11 @@ class AccountDetailsSpec extends BaseSpec {
     "read from json" in {
       implicit val ssf = JsonEncryption.sensitiveEncrypterDecrypter(SensitiveString.apply)(implicitly, crypto.crypto)
       val json = Json.obj(
-        "credId"        -> "credid",
-        "userId"        -> "userId",
-        "lastLoginDate" -> "lastLoginDate",
-        "email"         -> SensitiveString("foo"),
+        "identityProviderType" -> "SCP",
+        "credId"               -> "credid",
+        "userId"               -> "userId",
+        "lastLoginDate"        -> "lastLoginDate",
+        "email"                -> SensitiveString("foo"),
         "mfaDetails" -> Json.arr(
           Json.obj("factorNameKey" -> "mfaDetails.totp", "factorValue" -> "HMRC App")
         )
@@ -219,6 +228,7 @@ class AccountDetailsSpec extends BaseSpec {
 
       val accountDetails =
         AccountDetails(
+          identityProviderType = "SCP",
           "credid",
           "userId",
           Some(SensitiveString("foo")),
@@ -226,6 +236,7 @@ class AccountDetailsSpec extends BaseSpec {
           Seq(mfaDetailsTotp),
           None
         )
+
       Json.fromJson(json)(AccountDetails.mongoFormats(crypto.crypto)).get shouldBe accountDetails
       accountDetails.emailDecrypted shouldBe Some("foo")
     }

--- a/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/reporting/AuditEventSpec.scala
+++ b/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/reporting/AuditEventSpec.scala
@@ -29,6 +29,7 @@ import uk.gov.hmrc.taxenrolmentassignmentfrontend.repository.SessionKeys.{USER_A
 class AuditEventSpec extends BaseSpec {
 
   val accountDetailsWithOneMFADetails = AccountDetails(
+    identityProviderType = "SCP",
     credId = CREDENTIAL_ID_1,
     userId = "6037",
     email = Some(SensitiveString("test@mail.com")),

--- a/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/views/EnrolledForPTPageSpec.scala
+++ b/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/views/EnrolledForPTPageSpec.scala
@@ -20,17 +20,25 @@ import play.api.test.FakeRequest
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.controllers.routes
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.messages.EnrolledForPTPageMessages
+import uk.gov.hmrc.taxenrolmentassignmentfrontend.models.AccountDetails
 import uk.gov.hmrc.taxenrolmentassignmentfrontend.views.html.EnrolledForPTPage
 
 class EnrolledForPTPageSpec extends ViewSpecHelper {
-
+  val userId = "3214"
+  val accountDetails = AccountDetails(
+    identityProviderType = "SCP",
+    credId = "credId",
+    userId = userId,
+    email = None,
+    lastLoginDate = None,
+    mfaDetails = Seq.empty
+  )
   val enrolledForPTPage: EnrolledForPTPage =
     app.injector.instanceOf[EnrolledForPTPage]
-  val userId = "3214"
   val htmlWithSA: HtmlFormat.Appendable =
-    enrolledForPTPage(userId, true, routes.EnrolledForPTWithSAController.continue)(FakeRequest(), testMessages)
+    enrolledForPTPage(accountDetails, true, routes.EnrolledForPTWithSAController.continue)(FakeRequest(), testMessages)
   val htmlWithNoSA: HtmlFormat.Appendable =
-    enrolledForPTPage(userId, false, routes.EnrolledForPTController.continue)(FakeRequest(), testMessages)
+    enrolledForPTPage(accountDetails, false, routes.EnrolledForPTController.continue)(FakeRequest(), testMessages)
   val documentWithSA = doc(htmlWithSA)
   val documentWithNoSA = doc(htmlWithNoSA)
 

--- a/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/views/EnrolledForPTWithSAOnOtherAccountSpec.scala
+++ b/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/views/EnrolledForPTWithSAOnOtherAccountSpec.scala
@@ -36,6 +36,7 @@ class EnrolledForPTWithSAOnOtherAccountSpec extends ViewSpecHelper {
     MFADetails("Authenticator App", "HRMC APP")
   )
   val accountDetails: AccountDetails = AccountDetails(
+    identityProviderType = "SCP",
     credId = CREDENTIAL_ID,
     userId,
     Some(SensitiveString("email1@test.com")),

--- a/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/views/PTEnrolmentOnAnotherAccountSpec.scala
+++ b/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/views/PTEnrolmentOnAnotherAccountSpec.scala
@@ -51,6 +51,7 @@ class PTEnrolmentOnAnotherAccountSpec extends ViewSpecHelper {
   )
 
   val testAccountDetails = AccountDetails(
+    identityProviderType = "SCP",
     "credId",
     userId = USER_ID,
     email = Some(SensitiveString("email.otherUser@test.com")),
@@ -58,6 +59,7 @@ class PTEnrolmentOnAnotherAccountSpec extends ViewSpecHelper {
     mfaDetails
   )
   val testAccountDetailsWithSA = AccountDetails(
+    identityProviderType = "SCP",
     "credId",
     userId = PT_USER_ID,
     email = Some(SensitiveString("email.otherUser@test.com")),
@@ -67,6 +69,7 @@ class PTEnrolmentOnAnotherAccountSpec extends ViewSpecHelper {
   )
 
   val accountDetailsWithNoEmail: AccountDetails = AccountDetails(
+    identityProviderType = "SCP",
     "credId",
     userId = "9871",
     email = None,

--- a/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/views/ReportSuspiciousIDSpec.scala
+++ b/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/views/ReportSuspiciousIDSpec.scala
@@ -43,6 +43,7 @@ class ReportSuspiciousIDSpec extends ViewSpecHelper {
 
   val accountDetails: AccountDetails =
     AccountDetails(
+      identityProviderType = "SCP",
       "credId",
       "4533",
       Some(SensitiveString("email1@test.com")),

--- a/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/views/SignInWithSAAccountSpec.scala
+++ b/test/uk/gov/hmrc/taxenrolmentassignmentfrontend/views/SignInWithSAAccountSpec.scala
@@ -67,6 +67,7 @@ class SignInWithSAAccountSpec extends ViewSpecHelper {
   )
 
   val accountDetails: AccountDetails = AccountDetails(
+    identityProviderType = "SCP",
     credId = CREDENTIAL_ID,
     "********3214",
     Some(SensitiveString("email1@test.com")),


### PR DESCRIPTION
- improve remove of know facts during testing
- added call to stub for identity-provider-context (only works on a fork identity-provider-context)
- added on example of one login account